### PR TITLE
Resize etc experiments

### DIFF
--- a/src/modules/__start_handlers.js
+++ b/src/modules/__start_handlers.js
@@ -138,6 +138,12 @@ window.addEventListener("drop", (event) => {
 	}
 });
 
+// Keep track of the time of the last window resize...
+
+window.addEventListener("resize", (event) => {
+	hub.last_resize = performance.now();
+});
+
 // Uncaught exceptions should trigger an alert (once only)...
 
 window.addEventListener("error", (event) => {

--- a/src/modules/__start_handlers.js
+++ b/src/modules/__start_handlers.js
@@ -138,12 +138,6 @@ window.addEventListener("drop", (event) => {
 	}
 });
 
-// Keep track of the time of the last window resize...
-
-window.addEventListener("resize", (event) => {
-	hub.last_resize = performance.now();
-});
-
 // Uncaught exceptions should trigger an alert (once only)...
 
 window.addEventListener("error", (event) => {

--- a/src/modules/board_drawer.js
+++ b/src/modules/board_drawer.js
@@ -50,6 +50,8 @@ function new_board_drawer(backgrounddiv, htmltable, canvas, infodiv) {
 	drawer.canvas = canvas;
 	drawer.infodiv = infodiv;
 
+	drawer.ctx = canvas.getContext("2d");
+
 	drawer.width = null;
 	drawer.height = null;
 
@@ -135,7 +137,7 @@ let board_drawer_prototype = {
 	// set the size of something, relative to the square size...
 
 	fcircle: function(x, y, fraction, colour) {
-		let ctx = this.canvas.getContext("2d");
+		let ctx = this.ctx;
 		ctx.fillStyle = colour;
 		let gx = x * config.square_size + (config.square_size / 2);
 		let gy = y * config.square_size + (config.square_size / 2);
@@ -145,7 +147,7 @@ let board_drawer_prototype = {
 	},
 
 	circle: function(x, y, line_fraction, fraction, colour) {
-		let ctx = this.canvas.getContext("2d");
+		let ctx = this.ctx;
 		ctx.lineWidth = line_fraction * config.square_size;
 		ctx.strokeStyle = colour;
 		let gx = x * config.square_size + (config.square_size / 2);
@@ -156,7 +158,7 @@ let board_drawer_prototype = {
 	},
 
 	fsquare: function(x, y, fraction, colour) {
-		let ctx = this.canvas.getContext("2d");
+		let ctx = this.ctx;
 		ctx.fillStyle = colour;
 		let gx = x * config.square_size + (config.square_size / 2) - (config.square_size * fraction / 2);
 		let gy = y * config.square_size + (config.square_size / 2) - (config.square_size * fraction / 2);
@@ -164,7 +166,7 @@ let board_drawer_prototype = {
 	},
 
 	square: function(x, y, line_fraction, fraction, colour) {
-		let ctx = this.canvas.getContext("2d");
+		let ctx = this.ctx;
 		ctx.lineWidth = line_fraction * config.square_size;
 		ctx.strokeStyle = colour;
 		let gx = x * config.square_size + (config.square_size / 2);
@@ -179,7 +181,7 @@ let board_drawer_prototype = {
 	},
 
 	cross: function(x, y, line_fraction, colour) {
-		let ctx = this.canvas.getContext("2d");
+		let ctx = this.ctx;
 		ctx.lineWidth = line_fraction * config.square_size;
 		ctx.strokeStyle = colour;
 		let gx = x * config.square_size + (config.square_size / 2);
@@ -195,7 +197,7 @@ let board_drawer_prototype = {
 	},
 
 	triangle: function(x, y, line_fraction, colour) {
-		let ctx = this.canvas.getContext("2d");
+		let ctx = this.ctx;
 		ctx.lineWidth = line_fraction * config.square_size;
 		ctx.strokeStyle = colour;
 		let gx = x * config.square_size + (config.square_size / 2);
@@ -209,7 +211,7 @@ let board_drawer_prototype = {
 	},
 
 	text: function(x, y, msg, colour) {
-		let ctx = this.canvas.getContext("2d");
+		let ctx = this.ctx;
 		ctx.textAlign = "center";
 		ctx.textBaseline = "middle";
 		ctx.font = `${config.board_font_size}px Arial`;
@@ -220,7 +222,7 @@ let board_drawer_prototype = {
 	},
 
 	text_two: function(x, y, msg, msg2, colour) {
-		let ctx = this.canvas.getContext("2d");
+		let ctx = this.ctx;
 		ctx.textAlign = "center";
 		ctx.textBaseline = "middle";
 		ctx.font = `${config.board_font_size}px Arial`;
@@ -371,7 +373,7 @@ let board_drawer_prototype = {
 		// Based solely on whatever objects are in this.needed_marks...
 		// All planning functions have to be called before this.
 
-		let ctx = this.canvas.getContext("2d");
+		let ctx = this.ctx;
 		ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
 
 		this.death_marks = [];						// Cleared whenever canvas is cleared.

--- a/src/modules/grapher.js
+++ b/src/modules/grapher.js
@@ -25,12 +25,8 @@ let graph_drawer_prototype = {
 		return Math.max(0, Math.min(config.graph_width, window.innerWidth - this.canvas.getBoundingClientRect().left));
 	},
 
-	correct_height: function() {
-		return this.board_drawer.canvas.height + 128;
-	},
-
-	has_correct_size: function() {
-		return this.canvas.width === this.correct_width() && this.canvas.height === this.correct_height();
+	has_correct_width: function() {
+		return this.canvas.width === this.correct_width();
 	},
 
 	draw_graph: function(node) {
@@ -38,10 +34,10 @@ let graph_drawer_prototype = {
 		this.line_end = node.get_end();		// Set this now, before any early returns.
 
 		this.canvas.width = this.correct_width();
-		this.canvas.height = this.correct_height();
+		this.canvas.height = this.board_drawer.canvas.height + 128;
 
 		this.draw_x_offset = 16;
-		this.draw_y_offset = this.board_drawer.canvas.getBoundingClientRect().top - this.canvas.getBoundingClientRect().top + (config.square_size / 4);
+		this.draw_y_offset = config.square_size / 4;
 
 		this.drawable_width = Math.max(0, this.canvas.width - (this.draw_x_offset * 2));
 		this.drawable_height = Math.max(0, this.board_drawer.canvas.height - (config.square_size / 2));

--- a/src/modules/grapher.js
+++ b/src/modules/grapher.js
@@ -6,6 +6,9 @@ function new_grapher(canvas, positioncanvas) {
 
 	drawer.canvas = canvas;
 	drawer.positioncanvas = positioncanvas;
+	
+	drawer.ctx = canvas.getContext("2d");
+	drawer.posctx = positioncanvas.getContext("2d");
 
 	drawer.draw_x_offset = 0;									// These are all to
 	drawer.draw_y_offset = 0;									// be set later.
@@ -38,7 +41,7 @@ let graph_drawer_prototype = {
 			return;
 		}
 
-		let ctx = this.canvas.getContext("2d");
+		let ctx = this.ctx;
 
 		let history = this.line_end.history();
 
@@ -141,7 +144,7 @@ let graph_drawer_prototype = {
 			return;
 		}
 
-		let ctx = this.positioncanvas.getContext("2d");
+		let ctx = this.posctx;
 
 		// Position marker...
 
@@ -178,7 +181,7 @@ let graph_drawer_prototype = {
 
 	__draw_vals: function(vals, max_val, graph_length, linewidth) {
 
-		let ctx = this.canvas.getContext("2d");
+		let ctx = this.ctx;
 		ctx.lineWidth = linewidth;
 
 		let started = false;
@@ -215,7 +218,7 @@ let graph_drawer_prototype = {
 
 	__draw_interpolations: function(vals, max_val, graph_length, linewidth) {
 
-		let ctx = this.canvas.getContext("2d");
+		let ctx = this.ctx;
 		ctx.lineWidth = linewidth;
 		ctx.setLineDash([linewidth, linewidth * 2]);
 

--- a/src/modules/grapher.js
+++ b/src/modules/grapher.js
@@ -1,12 +1,11 @@
 "use strict";
 
-function new_grapher(canvas, positioncanvas, board_drawer) {	// board_drawer object provided so we can match its height; not used otherwise.
+function new_grapher(canvas, positioncanvas) {
 
 	let drawer = Object.create(graph_drawer_prototype);
 
 	drawer.canvas = canvas;
 	drawer.positioncanvas = positioncanvas;
-	drawer.board_drawer = board_drawer;
 
 	drawer.draw_x_offset = 0;									// These are all to
 	drawer.draw_y_offset = 0;									// be set later.
@@ -21,26 +20,18 @@ function new_grapher(canvas, positioncanvas, board_drawer) {	// board_drawer obj
 
 let graph_drawer_prototype = {
 
-	correct_width: function() {
-		return Math.max(0, Math.min(config.graph_width, window.innerWidth - this.canvas.getBoundingClientRect().left));
-	},
-
-	has_correct_width: function() {
-		return this.canvas.width === this.correct_width();
-	},
-
 	draw_graph: function(node) {
 
 		this.line_end = node.get_end();		// Set this now, before any early returns.
 
-		this.canvas.width = this.correct_width();
-		this.canvas.height = this.board_drawer.canvas.height + 128;
+		this.canvas.width = Math.max(0, Math.min(config.graph_width, window.innerWidth - this.canvas.getBoundingClientRect().left));
+		this.canvas.height = hub.maindrawer.canvas.height + 128;
 
 		this.draw_x_offset = 16;
 		this.draw_y_offset = config.square_size / 4;
 
 		this.drawable_width = Math.max(0, this.canvas.width - (this.draw_x_offset * 2));
-		this.drawable_height = Math.max(0, this.board_drawer.canvas.height - (config.square_size / 2));
+		this.drawable_height = Math.max(0, hub.maindrawer.canvas.height - (config.square_size / 2));
 
 		if (this.drawable_width <= 16 || this.drawable_height <= 0) {
 			this.draw_position(node);		// Just so it sets its size.

--- a/src/modules/hub.js
+++ b/src/modules/hub.js
@@ -39,13 +39,11 @@ exports.new_hub = function() {
 
 	hub.grapher = new_grapher(
 		document.getElementById("graphcanvas"),
-		document.getElementById("graphpositioncanvas"),
-		hub.maindrawer
+		document.getElementById("graphpositioncanvas")
 	);
 
 	hub.tree_drawer = new_tree_drawer(
-		document.getElementById("treecanvas"),
-		hub.grapher
+		document.getElementById("treecanvas")
 	);
 
 	hub.comment_drawer = new_comment_drawer(
@@ -70,6 +68,7 @@ exports.new_hub = function() {
 
 	hub.pending_up_down = 0;
 	hub.dropped_inputs = 0;
+	hub.last_resize = 0;
 
 	return hub;
 };

--- a/src/modules/hub.js
+++ b/src/modules/hub.js
@@ -938,7 +938,7 @@ let hub_props = {
 			config.height = height;
 
 			this.tree_drawer.must_draw = true;
-			
+
 			if (config.auto_square_size) {
 				let new_size = this.calculate_square_size();
 				if (new_size !== config.square_size) {
@@ -947,7 +947,7 @@ let hub_props = {
 			}
 		}
 
-		setTimeout(this.window_resize_checker.bind(this), 250);
+		setTimeout(this.window_resize_checker.bind(this), 125);
 	},
 
 	bad_death_mark_spinner: function() {

--- a/src/modules/hub.js
+++ b/src/modules/hub.js
@@ -68,7 +68,6 @@ exports.new_hub = function() {
 
 	hub.pending_up_down = 0;
 	hub.dropped_inputs = 0;
-	hub.last_resize = 0;
 
 	return hub;
 };

--- a/src/modules/hub.js
+++ b/src/modules/hub.js
@@ -895,14 +895,12 @@ let hub_props = {
 	},
 
 	graph_draw_spinner: function() {
-		this.grapher.draw_graph(this.node);
+		this.grapher.draw_graph(this.node);			// Always does a full draw, seems fast enough.
 		setTimeout(this.graph_draw_spinner.bind(this), Math.max(50, config.graph_draw_delay));				// Enforce minimum of 50
 	},
 
 	tree_draw_spinner: function() {
-		if (this.tree_drawer.central_node !== this.node || this.tree_drawer.must_draw) {
-			this.tree_drawer.draw_tree(this.node);
-		}
+		this.tree_drawer.draw_tree(this.node);		// Can skip the draw if not needed.
 		setTimeout(this.tree_draw_spinner.bind(this), Math.max(17, config.tree_draw_delay));				// Enforce minimum of 17
 	},
 
@@ -936,8 +934,6 @@ let hub_props = {
 
 			config.width = width;
 			config.height = height;
-
-			this.tree_drawer.must_draw = true;
 
 			if (config.auto_square_size) {
 				let new_size = this.calculate_square_size();

--- a/src/modules/hub.js
+++ b/src/modules/hub.js
@@ -929,13 +929,16 @@ let hub_props = {
 
 	window_resize_checker: function() {
 
-		let desired_config_width = Math.floor(window.innerWidth * zoomfactor);
-		let desired_config_height = Math.floor(window.innerHeight * zoomfactor);
+		let width = Math.floor(window.innerWidth * zoomfactor);
+		let height = Math.floor(window.innerHeight * zoomfactor);
 
-		if (config.width !== desired_config_width || config.height !== desired_config_height) {
-			config.width = desired_config_width;
-			config.height = desired_config_height;
+		if (config.width !== width || config.height !== height) {
+
+			config.width = width;
+			config.height = height;
+
 			this.tree_drawer.must_draw = true;
+			
 			if (config.auto_square_size) {
 				let new_size = this.calculate_square_size();
 				if (new_size !== config.square_size) {
@@ -943,6 +946,7 @@ let hub_props = {
 				}
 			}
 		}
+
 		setTimeout(this.window_resize_checker.bind(this), 250);
 	},
 

--- a/src/modules/hub_settings.js
+++ b/src/modules/hub_settings.js
@@ -68,16 +68,10 @@ module.exports = {
 			break;
 
 		case "board_line_width":
-
-			this.maindrawer.rebuild(this.node.get_board().width, this.node.get_board().height);
-			this.draw();
-			break;
-
 		case "square_size":
 
 			this.maindrawer.rebuild(this.node.get_board().width, this.node.get_board().height);
 			this.draw();
-			this.tree_drawer.must_draw = true;
 			break;
 
 		case "info_font_size":
@@ -89,7 +83,6 @@ module.exports = {
 					this.set("square_size", new_size);
 				}
 			}
-			this.tree_drawer.must_draw = true;
 			break;
 
 		case "board_font_size":
@@ -138,7 +131,6 @@ module.exports = {
 		case "comment_height":
 
 			this.comment_drawer.draw(this.node);
-			this.tree_drawer.must_draw = true;
 			break;
 
 		case "widerootnoise":

--- a/src/modules/tree_drawer.js
+++ b/src/modules/tree_drawer.js
@@ -5,11 +5,12 @@ function new_tree_drawer(canvas) {
 	let drawer = Object.create(tree_drawer_prototype);
 
 	drawer.canvas = canvas;
-	drawer.clickers = [];
+	drawer.ctx = canvas.getContext("2d");
 
+	drawer.clickers = [];
 	drawer.central_node = null;
 	drawer.must_draw = false;								// Not actually used by the drawer itself. Used by hub as one reason to call us.
-
+	
 	drawer.last_draw_cost = 0;								// Various things for debugging.
 	drawer.call_count = 0;
 	drawer.draw_count = 0;
@@ -66,7 +67,7 @@ let tree_drawer_prototype = {
 			provisional_central_node_gy + final_adjust_y
 		);
 
-		let ctx = this.canvas.getContext("2d");
+		let ctx = this.ctx;
 		ctx.fillStyle = config.central_node_colour;
 		ctx.fillRect(central_node.gx - config.tree_spacing / 3, central_node.gy - config.tree_spacing / 3, config.tree_spacing * 2 / 3, config.tree_spacing * 2 / 3);
 
@@ -76,7 +77,7 @@ let tree_drawer_prototype = {
 
 	__draw: function(local_root, central_node, central_node_gx, central_node_gy) {
 
-		let ctx = this.canvas.getContext("2d");
+		let ctx = this.ctx;
 
 		let node = local_root;
 

--- a/src/modules/tree_drawer.js
+++ b/src/modules/tree_drawer.js
@@ -11,6 +11,7 @@ function new_tree_drawer(canvas) {
 	drawer.must_draw = false;
 	
 	drawer.last_draw_cost = 0;								// Various things for debugging.
+	drawer.call_count = 0;									// Although this is actually used by real logic now.
 	drawer.draw_count = 0;
 
 	return drawer;
@@ -22,10 +23,13 @@ let tree_drawer_prototype = {
 
 		let start_time = performance.now();
 
+		this.call_count++;
+
 		let correct_width = Math.max(0, window.innerWidth - this.canvas.getBoundingClientRect().left);
 		let correct_height = Math.max(0, window.innerHeight - this.canvas.getBoundingClientRect().top - config.comment_height);
+		let size_is_ok = this.canvas.width === correct_width && this.canvas.height === correct_height;
 
-		if (!this.must_draw && this.canvas.width === correct_width && this.canvas.height === correct_height) {
+		if (!this.must_draw && (size_is_ok || this.call_count % 10 !== 0)) {
 			return;
 		}
 

--- a/src/modules/tree_drawer.js
+++ b/src/modules/tree_drawer.js
@@ -8,11 +8,9 @@ function new_tree_drawer(canvas) {
 	drawer.ctx = canvas.getContext("2d");
 
 	drawer.clickers = [];
-	drawer.central_node = null;
-	drawer.must_draw = false;								// Not actually used by the drawer itself. Used by hub as one reason to call us.
+	drawer.must_draw = false;
 	
 	drawer.last_draw_cost = 0;								// Various things for debugging.
-	drawer.call_count = 0;
 	drawer.draw_count = 0;
 
 	return drawer;
@@ -23,15 +21,23 @@ let tree_drawer_prototype = {
 	draw_tree: function(central_node) {
 
 		let start_time = performance.now();
-		this.call_count++;
+
+		let correct_width = Math.max(0, window.innerWidth - this.canvas.getBoundingClientRect().left);
+		let correct_height = Math.max(0, window.innerHeight - this.canvas.getBoundingClientRect().top - config.comment_height);
+
+		if (!this.must_draw && this.canvas.width === correct_width && this.canvas.height === correct_height) {
+			return;
+		}
+
+		// Reset state...
+
 		this.must_draw = false;
 		this.clickers = [];
-		this.central_node = central_node;					// Don't make this null, ever, it will provoke the spinner.
 
 		// Always blank the canvas...
 
-		this.canvas.width = Math.max(0, window.innerWidth - this.canvas.getBoundingClientRect().left);
-		this.canvas.height = Math.max(0, window.innerHeight - this.canvas.getBoundingClientRect().top - config.comment_height);
+		this.canvas.width = correct_width;
+		this.canvas.height = correct_height;
 
 		// Various reasons why we might leave everything blank...
 

--- a/src/modules/tree_drawer.js
+++ b/src/modules/tree_drawer.js
@@ -1,11 +1,10 @@
 "use strict";
 
-function new_tree_drawer(canvas, grapher) {					// grapher object provided so we can check its size; not used otherwise.
+function new_tree_drawer(canvas) {
 
 	let drawer = Object.create(tree_drawer_prototype);
 
 	drawer.canvas = canvas;
-	drawer.grapher = grapher;
 	drawer.clickers = [];
 
 	drawer.central_node = null;
@@ -24,21 +23,12 @@ let tree_drawer_prototype = {
 
 		let start_time = performance.now();
 		this.call_count++;
-
+		this.must_draw = false;
 		this.clickers = [];
 		this.central_node = central_node;					// Don't make this null, ever, it will provoke the spinner.
 
-		// The graph (to the left of the tree) may be the wrong size if the window is being resized.
-		// Don't modify the canvas at all until that situation resolves itself...
+		// Always blank the canvas...
 
-		if (this.grapher.has_correct_width() === false) {
-			this.must_draw = true;							// Ensure we actually draw once the graph has resized correctly.
-			return;
-		}
-
-		// We're committed to a draw of some sort, which might just be blanking the canvas...
-
-		this.must_draw = false;
 		this.canvas.width = Math.max(0, window.innerWidth - this.canvas.getBoundingClientRect().left);
 		this.canvas.height = Math.max(0, window.innerHeight - this.canvas.getBoundingClientRect().top - config.comment_height);
 

--- a/src/modules/tree_drawer.js
+++ b/src/modules/tree_drawer.js
@@ -31,7 +31,7 @@ let tree_drawer_prototype = {
 		// The graph (to the left of the tree) may be the wrong size if the window is being resized.
 		// Don't modify the canvas at all until that situation resolves itself...
 
-		if (this.grapher.has_correct_size() === false) {
+		if (this.grapher.has_correct_width() === false) {
 			this.must_draw = true;							// Ensure we actually draw once the graph has resized correctly.
 			return;
 		}

--- a/src/modules/tree_drawer.js
+++ b/src/modules/tree_drawer.js
@@ -33,17 +33,13 @@ let tree_drawer_prototype = {
 			return;
 		}
 
-		// Reset state...
+		// We're going to do some sort of draw, maybe just clearing the canvas...
 
 		this.must_draw = false;
 		this.clickers = [];
 
-		// Always blank the canvas...
-
 		this.canvas.width = correct_width;
 		this.canvas.height = correct_height;
-
-		// Various reasons why we might leave everything blank...
 
 		if (this.canvas.width <= config.tree_spacing || this.canvas.height <= config.tree_spacing) {
 			return;
@@ -52,7 +48,7 @@ let tree_drawer_prototype = {
 			return;
 		}
 
-		// We're committed to a full draw...
+		// Full draw...
 
 		this.draw_count++;
 

--- a/src/ogatak.css
+++ b/src/ogatak.css
@@ -23,11 +23,21 @@ body {
 	display: none;		/* set to grid by renderer.js, just done like this to hide it until script is active. */
 	height: 100vh;
 	grid-template-columns: min-content min-content min-content 1fr;
-	grid-template-rows: min-content min-content 1fr;
+	grid-template-rows: min-content 1fr;
 	grid-template-areas:
 		"d a a e"
-		"d b c e"
-		"d b c f";
+		"d b c e";
+}
+
+#right_gridder {
+	display: grid;
+	grid-area: e;
+	height: 100vh;
+	grid-template-columns: 1fr;
+	grid-template-rows: min-content 1fr;
+	grid-template-areas:
+		"f"
+		"g";
 }
 
 #tabdiv {
@@ -40,17 +50,6 @@ body {
 	overflow-x: hidden;
 	overflow-y: scroll;
 	pointer-events: auto;
-}
-
-#comments {
-	background-color: #181818ff;
-	grid-area: f;
-	font-family: monospace, monospace;
-	margin: 0;
-	overflow-x: hidden;
-	overflow-y: auto;
-	padding: 0.5em 0.5em 0.5em 0.5em;
-	white-space: pre-wrap;
 }
 
 #graphcanvas {
@@ -72,8 +71,19 @@ body {
 #treecanvas {
 	background-color: #111111ff;
 	display: block;
-	grid-area: e;
+	grid-area: f;
 	margin: 0 0 0 0;
+}
+
+#comments {
+	background-color: #181818ff;
+	grid-area: g;
+	font-family: monospace, monospace;
+	margin: 0;
+	overflow-x: hidden;
+	overflow-y: auto;
+	padding: 0.5em 0.5em 0.5em 0.5em;
+	white-space: pre-wrap;
 }
 
 #boardbg {

--- a/src/ogatak.css
+++ b/src/ogatak.css
@@ -56,14 +56,16 @@ body {
 #graphcanvas {
 	display: block;						/* Stops the parent element from being 4px bigger... */
 	grid-area: c;
-	margin: 16px 0 0 0;
+	margin-top: 16px;
+	margin-left: auto;
 	z-index: 1;
 }
 
 #graphpositioncanvas {
 	display: block;						/* Stops the parent element from being 4px bigger... */
 	grid-area: c;
-	margin: 16px 0 0 0;
+	margin-top: 16px;
+	margin-left: auto;
 	z-index: 2;
 }
 

--- a/src/ogatak.css
+++ b/src/ogatak.css
@@ -56,14 +56,14 @@ body {
 #graphcanvas {
 	display: block;						/* Stops the parent element from being 4px bigger... */
 	grid-area: c;
-	margin: 0;
+	margin: 16px 0 0 0;
 	z-index: 1;
 }
 
 #graphpositioncanvas {
 	display: block;						/* Stops the parent element from being 4px bigger... */
 	grid-area: c;
-	margin: 0;
+	margin: 16px 0 0 0;
 	z-index: 2;
 }
 

--- a/src/ogatak.html
+++ b/src/ogatak.html
@@ -11,25 +11,29 @@
 
 	<div id="gridder">
 
-		<div id="tabdiv"></div>
-
-		<div id="boardbg"></div>							<!-- wood texture only -->
-		<table id="boardtable"></table>						<!-- lines (as BG image) and stones (in td elements) -->
-		<canvas id="boardcanvas"></canvas>					<!-- analysis etc -->
-
 		<div id="preloaders">
 			<img src="./gfx/black_stone.png">				<!-- I noticed that these images flickered the first -->
 			<img src="./gfx/white_stone.png">				<!-- time they appear so trying this as a solution.  -->
 			<img src="./gfx/ko.png">
 		</div>
 
+		<!--------------------------------------------------------------------------------------------------------->
+
+		<div id="tabdiv"></div>
+		
 		<div id="boardinfo"></div>
+
+		<div id="boardbg"></div>							<!-- wood texture only -->
+		<table id="boardtable"></table>						<!-- lines (as BG image) and stones (in td elements) -->
+		<canvas id="boardcanvas"></canvas>					<!-- analysis etc -->
 
 		<canvas id="graphcanvas"></canvas>
 		<canvas id="graphpositioncanvas"></canvas>
 
-		<canvas id="treecanvas"></canvas>
-		<div id="comments"></div>
+		<div id="right_gridder">
+			<canvas id="treecanvas"></canvas>
+			<div id="comments"></div>
+		</div>
 
 	</div>
 


### PR DESCRIPTION
* Added a nested subgrid for the right column (tree / comment)
* Tree drawer now does more of the logic of when to draw.
* Tree drawer no longer stores what node it drew.
* Many getContext() calls removed - use cached item.
* new_grapher and new_tree_drawer no longer get args referencing other drawers.