### PR TITLE
Distinguish the next move.

### DIFF
--- a/src/modules/board_drawer.js
+++ b/src/modules/board_drawer.js
@@ -946,9 +946,13 @@ let board_drawer_prototype = {
 
 		for (let n = 0; n < node.children.length; n++) {
 
+			let is_main_line = (n === 0 && node.children.length !== 1);
+
 			for (let key of ["B", "W"]) {
 
-				let draw_colour = (key === "B") ? "#00000080" : "#ffffffa0";
+				let black_code = is_main_line ? "#000000d0" : "#00000080";
+				let white_code = is_main_line ? "#fffffff0" : "#ffffffa0";
+				let draw_colour = (key === "B") ? black_code : white_code;
 
 				let moves_played = node.children[n].all_values(key);
 
@@ -964,6 +968,7 @@ let board_drawer_prototype = {
 							if (this.needed_marks[x][y]) {
 								if (!this.needed_marks[x][y].next_mark_colour) {
 									this.needed_marks[x][y].next_mark_colour = draw_colour;
+									this.needed_marks[x][y].is_main_line = is_main_line;
 								} else {
 									// We already have this mark due to some sibling, do nothing.
 								}
@@ -971,6 +976,7 @@ let board_drawer_prototype = {
 								this.needed_marks[x][y] = {
 									type: "next",
 									next_mark_colour: draw_colour,
+									is_main_line: is_main_line,
 								};
 							}
 						}


### PR DESCRIPTION
Add support for distinguishing the next move when there are 2+ moves. This feature is in the TODO list #15. 

Black  Effect
![Screenshot from 2022-10-02 02-42-00](https://user-images.githubusercontent.com/39462842/193423767-66d5b6c2-cdc4-419b-86ef-964c5a8aa547.png)

White Effect
![Screenshot from 2022-10-02 02-42-09](https://user-images.githubusercontent.com/39462842/193423771-b73389c5-c9e5-4adb-85b0-6c62dbd7687a.png)
