### PR TITLE
fix typo

### DIFF
--- a/src/modules/translations.js
+++ b/src/modules/translations.js
@@ -686,7 +686,7 @@ translations[`繁體中文`] = {
 		MENU_SET_RULES: `規則`,
 			MENU_CHINESE: `中國`,
 			MENU_JAPANESE: `日本`,
-			MENU_STONE_SCORING: `還頭棋`,
+			MENU_STONE_SCORING: `還棋頭`,
 		MENU_SET_KOMI: `貼目`,
 		MENU_PV_LENGTH_MAX: `主變化最大顯示深度`,
 		MENU_WIDE_ROOT_NOISE: `根節點廣化噪音`,


### PR DESCRIPTION
it should be 還棋頭 instead of 還頭棋
https://zh.wikipedia.org/zh-tw/%E5%9C%8D%E6%A3%8B%E8%A6%8F%E5%89%87%E6%AF%94%E8%BC%83#%E8%BF%98%E6%A3%8B%E5%A4%B4