### PR TITLE
Ignore isDuringSearch

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -2371,17 +2371,6 @@ function menu_build() {
 					type: "separator",
 				},
 				{
-					label: translate("MENU_SNAPPY_NODE_SWITCH_HACK"),
-					type: "checkbox",
-					checked: config.snappy_node_switch,
-					click: () => {
-						win.webContents.send("toggle", "snappy_node_switch");
-					}
-				},
-				{
-					type: "separator",
-				},
-				{
 					label: translate("MENU_SHOW_CONFIG_FILE"),
 					click: () => {
 						electron.shell.showItemInFolder(config_io.filepath);

--- a/src/modules/config_io.js
+++ b/src/modules/config_io.js
@@ -95,7 +95,6 @@ exports.defaults = {
 	"ownership_per_move": true,
 
 	"zobrist_checks": true,
-	"snappy_node_switch": true,
 	"fast_first_report": true,
 
 	"play_against_policy": false,

--- a/src/modules/engine.js
+++ b/src/modules/engine.js
@@ -231,9 +231,14 @@ class Engine {
 					running_has_finished = true;
 				}
 			}
+			if (o.error) {
+				if (this.running && this.running.id === o.id) {
+					running_has_finished = true;
+				}
+			}
 
 // ---------------------------------- Experiment - what if we just don't do this?? ---------------------------------------------------------------
-//			if (o.isDuringSearch === false || o.error) {						// Every analysis request generates exactly 1 of these eventually.
+//			if (o.isDuringSearch === false) {									// Every analysis request generates exactly 1 of these eventually.
 //				if (this.running && this.running.id === o.id) {					// Upon receipt, the search is completely finished.
 //					running_has_finished = true;
 //				}

--- a/src/modules/engine.js
+++ b/src/modules/engine.js
@@ -139,7 +139,6 @@ class Engine {
 				["analysis", "-config", this.engineconfig, "-model", this.weights, "-quit-without-waiting"],
 				{cwd: path.dirname(this.filepath)}
 			);
-			console.log(`${this.filepath} analysis -config ${this.engineconfig} -model ${this.weights}`);
 		} catch (err) {
 			this.log_and_alert("While spawning engine:", err.toString());
 			return;

--- a/src/modules/engine.js
+++ b/src/modules/engine.js
@@ -43,6 +43,8 @@ class Engine {
 		this.engineconfig = "";
 		this.weights = "";
 
+		// Note that for experiment in 1.9.6, the following will not be null'd just because we receive isDuringSearch: false...
+
 		this.desired = null;				// The search object we want to be running.
 		this.running = null;				// The search object actually running. (Possibly the same object as above.)
 	}

--- a/src/modules/engine.js
+++ b/src/modules/engine.js
@@ -232,12 +232,13 @@ class Engine {
 				}
 			}
 
-// -- Experiment - what if we just don't do this?? --------------------------
+// ---------------------------------- Experiment - what if we just don't do this?? ---------------------------------------------------------------
 //			if (o.isDuringSearch === false || o.error) {						// Every analysis request generates exactly 1 of these eventually.
 //				if (this.running && this.running.id === o.id) {					// Upon receipt, the search is completely finished.
 //					running_has_finished = true;
 //				}
 //			}
+// -----------------------------------------------------------------------------------------------------------------------------------------------
 
 			if (running_has_finished) {
 				if (this.desired === this.running) {

--- a/src/modules/engine.js
+++ b/src/modules/engine.js
@@ -5,8 +5,7 @@
 // We only ever have one query active at a time, so we must receive an indication that the
 // previous query has terminated (or at least is terminating) before sending the next one.
 //
-// Our canonical concept of "state" is that the app is trying to ponder if desired is not
-// null, therefore every time desired is set, the relevant menu check should be set.
+// Our canonical concept of "state" is that the app is trying to ponder if desired != null
 
 const child_process = require("child_process");
 const fs = require("fs");

--- a/src/modules/engine.js
+++ b/src/modules/engine.js
@@ -138,6 +138,7 @@ class Engine {
 				["analysis", "-config", this.engineconfig, "-model", this.weights, "-quit-without-waiting"],
 				{cwd: path.dirname(this.filepath)}
 			);
+			console.log(`${this.filepath} analysis -config ${this.engineconfig} -model ${this.weights}`);
 		} catch (err) {
 			this.log_and_alert("While spawning engine:", err.toString());
 			return;
@@ -226,18 +227,19 @@ class Engine {
 				}
 			}
 			let running_has_finished = false;
-			if (config.snappy_node_switch) {
-				if (o.action === "terminate") {									// We get these back very quickly upon sending a "terminate", however Kata
-					if (this.running && this.running.id === o.terminateId) {	// may send further updates in a little bit (10-100 ms or so). While that's
-						running_has_finished = true;							// not a problem, it's a bit impure and so this behaviour is off by default.
-					}
-				}
-			}
-			if (o.isDuringSearch === false || o.error) {						// Every analysis request generates exactly 1 of these eventually.
-				if (this.running && this.running.id === o.id) {					// Upon receipt, the search is completely finished.
+			if (o.action === "terminate") {										// We get these back very quickly upon sending a "terminate", however
+				if (this.running && this.running.id === o.terminateId) {		// Kata may send further updates in a little bit (10-100 ms or so).
 					running_has_finished = true;
 				}
 			}
+
+// -- Experiment - what if we just don't do this?? --------------------------
+//			if (o.isDuringSearch === false || o.error) {						// Every analysis request generates exactly 1 of these eventually.
+//				if (this.running && this.running.id === o.id) {					// Upon receipt, the search is completely finished.
+//					running_has_finished = true;
+//				}
+//			}
+
 			if (running_has_finished) {
 				if (this.desired === this.running) {
 					this.desired = null;

--- a/src/modules/enums.js
+++ b/src/modules/enums.js
@@ -1,0 +1,11 @@
+"use strict";
+
+module.exports = {
+	NONE:         0,
+	AUTOANALYSIS: 1,
+	BACKANALYSIS: 2,
+	SELFPLAY:     3,
+	AUTOSCROLL:   4,
+	PLAY_BLACK:   5,
+	PLAY_WHITE:   6,
+};

--- a/src/modules/hub.js
+++ b/src/modules/hub.js
@@ -70,11 +70,7 @@ let hub_main_props = {
 			}
 		}
 
-		let want_antiflicker = Boolean(this.engine.desired);
-
-		if (this.playing_active_colour()) {
-			want_antiflicker = false;
-		}
+		let want_antiflicker = Boolean(this.engine.desired) && !this.playing_active_colour();
 
 		if (!did_draw_pv) {
 			board_drawer.draw_standard(this.node, want_antiflicker);

--- a/src/modules/hub.js
+++ b/src/modules/hub.js
@@ -22,9 +22,7 @@ const config_io = require("./config_io");
 const {translate} = require("./translate");
 const {node_id_from_search_id, valid_analysis_object, compare_versions, xy_to_s} = require("./utils");
 
-// Special modes... (these do not include editing modes such as AB mode, etc)
-
-const NONE = 0, AUTOANALYSIS = 1, BACKANALYSIS = 2, SELFPLAY = 3, AUTOSCROLL = 4, PLAY_BLACK = 5, PLAY_WHITE = 6;
+const {NONE, AUTOANALYSIS, BACKANALYSIS, SELFPLAY, AUTOSCROLL, PLAY_BLACK, PLAY_WHITE} = require("./enums");
 
 // ------------------------------------------------------------------------------------------------
 

--- a/src/modules/hub.js
+++ b/src/modules/hub.js
@@ -73,15 +73,7 @@ let hub_main_props = {
 		}
 
 		if (!did_draw_pv) {
-
-			// Should the drawer use ownership of a nearby node if ownership is not present in this.node? It both prevents flicker when advancing,
-			// and is the only way to get ownership drawn at all if the position is advancing rapidly (e.g. due to play_against_policy mode):
-
-			let want_antiflicker = Boolean(this.engine.desired || [AUTOANALYSIS, BACKANALYSIS, SELFPLAY].includes(this.play_mode));
-
-			// Note that engine.desired may be briefly null while switching nodes in these modes, so it's not redundant to test.
-
-			board_drawer.draw_standard(this.node, want_antiflicker);
+			board_drawer.draw_standard(this.node, Boolean(this.engine.desired));
 		}
 	},
 
@@ -707,9 +699,6 @@ let hub_main_props = {
 					} else {
 						this.play_top_policy();
 					}
-					if (!this.engine.desired) {
-						this.go();
-					}
 				}
 
 			} else if (o.rootInfo.visits >= config.autoanalysis_visits) {
@@ -725,9 +714,6 @@ let hub_main_props = {
 
 					if (this.node.children.length > 0) {
 						this.next_auto();
-						if (!this.engine.desired) {
-							this.go();
-						}
 					} else {
 						this.halt();
 					}
@@ -736,9 +722,6 @@ let hub_main_props = {
 
 					if (this.node.parent) {
 						this.prev_auto();
-						if (!this.engine.desired) {
-							this.go();
-						}
 					} else {
 						this.halt();
 					}
@@ -749,9 +732,6 @@ let hub_main_props = {
 						this.halt();
 					} else {
 						this.play_best();
-						if (!this.engine.desired) {
-							this.go();
-						}
 					}
 				}
 			}

--- a/src/modules/hub_settings.js
+++ b/src/modules/hub_settings.js
@@ -8,6 +8,8 @@ const {defaults} = require("./config_io");
 const {translate} = require("./translate");
 const {compare_arrays} = require("./utils");
 
+const {NONE, AUTOANALYSIS, BACKANALYSIS, SELFPLAY, AUTOSCROLL, PLAY_BLACK, PLAY_WHITE} = require("./enums");
+
 const multichecks = {
 	// Some special submenus are not included here, when their values don't match their labels.
 	report_every:			[translate("MENU_SETUP"), translate("MENU_ENGINE_REPORT_RATE")],
@@ -236,11 +238,17 @@ module.exports = {
 		case "play_against_policy":					// These 2 things...
 
 			if (value) config.play_against_drunk = false;
+			if (this.play_mode === SELFPLAY || this.playing_active_colour()) {
+				this.go();
+			}
 			break;
 
 		case "play_against_drunk":					// ... are mutually exclusive. Also need a special menu-handler.
 
 			if (value) config.play_against_policy = false;
+			if (this.play_mode === SELFPLAY || this.playing_active_colour()) {
+				this.go();
+			}
 			break;
 
 		case "enable_hw_accel":

--- a/src/modules/hub_settings.js
+++ b/src/modules/hub_settings.js
@@ -237,17 +237,23 @@ module.exports = {
 
 		case "play_against_policy":					// These 2 things...
 
-			if (value) config.play_against_drunk = false;
-			if (this.play_mode === SELFPLAY || this.playing_active_colour()) {
-				this.go();
+			if (value) {
+				config.play_against_drunk = false;
+			} else {
+				if (this.play_mode === SELFPLAY || this.playing_active_colour()) {
+					this.go();	// Need more visits.
+				}
 			}
 			break;
 
 		case "play_against_drunk":					// ... are mutually exclusive. Also need a special menu-handler.
 
-			if (value) config.play_against_policy = false;
-			if (this.play_mode === SELFPLAY || this.playing_active_colour()) {
-				this.go();
+			if (value) {
+				config.play_against_policy = false;
+			} else {
+				if (this.play_mode === SELFPLAY || this.playing_active_colour()) {
+					this.go();	// Need more visits.
+				}
 			}
 			break;
 

--- a/src/modules/hub_settings.js
+++ b/src/modules/hub_settings.js
@@ -46,7 +46,6 @@ const togglechecks = {
 	tygem_3:				[translate("MENU_MISC"), translate("MENU_PREFER_TYGEM_HANDICAP_3_LAYOUT")],
 	enable_hw_accel:		[translate("MENU_MISC"), translate("MENU_ENABLE_HARDWARE_ACCELERATION_FOR_GUI")],
 	zobrist_checks:			[translate("MENU_DEV"), translate("MENU_ZOBRIST_MISMATCH_CHECKS")],
-	snappy_node_switch:		[translate("MENU_DEV"), translate("MENU_SNAPPY_NODE_SWITCH_HACK")],
 };
 
 // The following lines just ask main process to check the menupath exists,

--- a/src/modules/query.js
+++ b/src/modules/query.js
@@ -12,6 +12,7 @@
 const {node_id_from_search_id, compare_versions} = require("./utils");
 
 const default_maxvisits = 1000000;
+const fast_maxvisits = 5;										// What the hub will ask for when in play policy mode.
 
 let next_query_id = 1;
 
@@ -44,10 +45,14 @@ function new_query(query_node, eng_version = null, maxvisits = default_maxvisits
 		}
 	};
 
+	if (maxvisits <= fast_maxvisits) {
+		delete o.reportDuringSearchEvery;
+	}
+
 	// Some features of KataGo were added along the way, only set those if the engine version is adequate...
 
 	if (eng_version && compare_versions(eng_version, [1,12,0]) >= 0) {
-		if (config.fast_first_report) {
+		if (config.fast_first_report && maxvisits > fast_maxvisits) {
 			o.firstReportDuringSearchAfter = 0.05;
 		}
 	}
@@ -173,4 +178,4 @@ function compare_moves_arrays(arr1, arr2) {			// Works for initialStones as well
 
 
 
-module.exports = {default_maxvisits, new_query, compare_queries, compare_moves_arrays};
+module.exports = {default_maxvisits, fast_maxvisits, new_query, compare_queries, compare_moves_arrays};


### PR DESCRIPTION
This restores the rule that, if `engine.desired` is set to something, the app is in the state of wanting to run analysis.

It may mean that sometimes we send a `terminate` command to the engine after the query completed with `isDuringSearch: false` (and KataGo will never send a second one) thus we will make the snappy node switch hack mandatory so we can still have a way to set desired to null when we actually want to put the app in a halted state - this works because KataGo still acknowledges our `terminate` command.

With that done, we can stop worrying about engine.desired not being set when receiving analysis in special modes. When we call `set_node()` it will once again call `go()` as it used to, since it will see `engine.desired` existing.