### PR TITLE
Delay root move

### DIFF
--- a/src/modules/node.js
+++ b/src/modules/node.js
@@ -827,6 +827,13 @@ class Node {
 		return !this.parent && this.children.length === 0 && !this.has_key("AB") && !this.has_key("AW") && !this.has_key("B") && !this.has_key("W");
 	}
 
+	increase_depth() {
+		let deepest = increase_depth_recursive(this);
+		if (deepest > this.get_root().graph_depth) {
+			this.get_root().graph_depth = deepest;
+		}
+	}
+
 	detach() {
 
 		let parent = this.parent;
@@ -1240,6 +1247,28 @@ function forget_analysis_recursive(node) {
 			continue;
 		} else {
 			break;
+		}
+	}
+}
+
+function increase_depth_recursive(node) {		// Returns the depth of the deepest node in the recurse.
+
+	while (true) {
+		node.depth++;
+		if (node.children.length > 1) {
+			let deepest_subtree = 0;
+			for (let child of node.children) {
+				let d = increase_depth_recursive(child);
+				if (d > deepest_subtree) {
+					deepest_subtree = d;
+				}
+			}
+			return deepest_subtree;
+		} else if (node.children.length === 1) {
+			node = node.children[0];
+			continue;
+		} else {
+			return node.depth;
 		}
 	}
 }

--- a/src/modules/root_fixes.js
+++ b/src/modules/root_fixes.js
@@ -103,24 +103,22 @@ function fix_singleton_handicap(root) {
 }
 
 function delay_root_move(root) {
-	if (root.move_count() !== 1 || root.has_key("AB") || root.has_key("AW") || root.has_key("AE")) {
+	if (root.move_count() !== 1 || root.has_key("AB") || root.has_key("AW") || root.has_key("AE") || root.has_key("PL")) {
 		return;
 	}
 	let orig_children = root.children;
 	root.children = [];
 	let inserted_node = new_node(root);
 	inserted_node.children = orig_children;
-	if (root.has_key("B")) {
-		inserted_node.set("B", root.get("B"));
-		root.delete_key("B");
-	}
-	if (root.has_key("W")) {
-		inserted_node.set("W", root.get("W"));
-		root.delete_key("W");
-	}
 	for (let child of orig_children) {
 		child.parent = inserted_node;
 		child.increase_depth();
+	}
+	for (let key of ["B", "W"]) {
+		if (root.has_key(key)) {
+			inserted_node.set(key, root.get(key));
+			root.delete_key(key);
+		}
 	}
 }
 
@@ -137,11 +135,11 @@ function apply_all_fixes(root, guess_ruleset) {
 	apply_ruleset_fixes(root);
 	purge_newlines(root);
 	fix_singleton_handicap(root);
-	delay_root_move(root);
-	apply_pl_fix(root);					// After  delay_root_move()
+	delay_root_move(root);				// After fix_singleton_handicap()
+	apply_pl_fix(root);					// After delay_root_move()
 
 	if (guess_ruleset) {
-		apply_ruleset_guess(root);		// After  apply_komi_fix()
+		apply_ruleset_guess(root);		// After apply_komi_fix()
 	}
 }
 

--- a/src/modules/root_fixes.js
+++ b/src/modules/root_fixes.js
@@ -134,14 +134,14 @@ function apply_ruleset_guess(root) {
 function apply_all_fixes(root, guess_ruleset) {
 
 	apply_komi_fix(root);
-	apply_pl_fix(root);
 	apply_ruleset_fixes(root);
 	purge_newlines(root);
 	fix_singleton_handicap(root);
 	delay_root_move(root);
+	apply_pl_fix(root);					// After  delay_root_move()
 
 	if (guess_ruleset) {
-		apply_ruleset_guess(root);		// AFTER the komi fix, above.
+		apply_ruleset_guess(root);		// After  apply_komi_fix()
 	}
 }
 


### PR DESCRIPTION
When the root node contains a move, insert a new node after the root, and transfer the move to there instead.