### PR TITLE
Update CN translation and fix padding size for CN

### DIFF
--- a/src/modules/board_drawer.js
+++ b/src/modules/board_drawer.js
@@ -1101,7 +1101,8 @@ let board_drawer_prototype = {
 			rules = t.Unknown;
 		}
 
-		s1 += `<span class="boardinfo_rules">${t.Rules}: <span class="white">${pad(rules, 16)}</span></span>`;
+        let first_paddings = config.language == `繁體中文` ? 20 : 16; 
+		s1 += `<span class="boardinfo_rules">${t.Rules}: <span class="white">${pad(rules, first_paddings)}</span></span>`;
 		s1 += `<span class="boardinfo_komi">${t.Komi}: <span class="white">${pad(node.komi(), 8)}</span></span>`;
 
 		if (config.editing) {

--- a/src/modules/translations.js
+++ b/src/modules/translations.js
@@ -818,7 +818,7 @@ translations[`繁體中文`] = {
 	INFO_PANEL_SHOW: `顯示`,
 	INFO_PANEL_B: `黑`,
 	INFO_PANEL_W: `白`,
-	INFO_PANEL_SCORE: `領先目數`,
+	INFO_PANEL_SCORE: `目差`,
 	INFO_PANEL_STN: `棋子數`,
 	INFO_PANEL_CAPS: `提子數`,
 	INFO_PANEL_THIS: `本點位`,


### PR DESCRIPTION
Update the a transition of a label and the paddings. Now the board info box looks like this...
![Screenshot from 2024-10-11 15-21-53](https://github.com/user-attachments/assets/796840b4-68f3-40f7-828d-3eb4718d119f)
