### PR TITLE
Add next mistake and previous mistake buttons

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -699,6 +699,23 @@ function menu_build() {
 					type: "separator",
 				},
 				{
+					label: translate("MENU_NEXT_MISTAKE"),
+					accelerator: "CommandOrControl+Shift+N",
+					click: () => {
+						win.webContents.send("call", "next_mistake");
+					}
+				},
+				{
+					label: translate("MENU_PREVIOUS_MISTAKE"),
+					accelerator: "CommandOrControl+Shift+P",
+					click: () => {
+						win.webContents.send("call", "previous_mistake");
+					}
+				},
+				{
+					type: "separator",
+				},
+				{
 					label: translate("MENU_BACKWARD"),
 					accelerator: "Up",			// Likely intercepted by the renderer process, see __start_handlers.js
 					click: () => {

--- a/src/modules/hub.js
+++ b/src/modules/hub.js
@@ -668,6 +668,41 @@ let hub_main_props = {
 		this.draw();
 	},
 
+	next_mistake: function() {
+		let delta_score = 0
+		let current_node = this.node
+		while (delta_score > -3 && current_node.children.length > 0) {
+			current_node = current_node.get_blessed_child()
+			const last_score = current_node.parent.stored_score()
+			delta_score = current_node.stored_score() - last_score
+			if (current_node.has_key("W")) {
+				delta_score = delta_score * -1
+			}
+
+		}
+		this.set_node(current_node, {bless: false});
+	},
+
+	previous_mistake: function() {
+		let delta_score = 0
+		let current_node = this.node
+		let last_node = this.node
+		if (!current_node.parent)
+			return
+		current_node = current_node.parent
+		while (delta_score > -3 && current_node.parent) {
+			const last_score = current_node.stored_score()
+			delta_score = last_score - current_node.parent.stored_score()
+			if (current_node.has_key("W")) {
+				delta_score = delta_score * -1
+			}
+			last_node = current_node
+			current_node = current_node.parent
+		}
+		this.set_node(last_node, {bless: false});
+
+	},
+
 	// Engine......................................................................................
 
 	receive_object: function(o) {

--- a/src/modules/translations.js
+++ b/src/modules/translations.js
@@ -65,6 +65,8 @@ translations[`English`] = {
 		MENU_PROMOTE_LINE_TO_MAIN_LINE: `Promote line to main line`,
 		MENU_DELETE_NODE: `Delete node`,
 		MENU_DELETE_ALL_PREVIOUS_FORKS: `Delete all previous forks`,
+		MENU_NEXT_MISTAKE: `Next Mistake`,
+		MENU_PREVIOUS_MISTAKE: `Previous Mistake`,
 
 	MENU_TOOLS: `Tools`,
 


### PR DESCRIPTION
The next mistake button will jump to the next move that drops in score by at least 3 points. This is a feature inspired by a similar feature in katrain, however I like the interface of ogatak more and would like to start using it instead. The previous mistake button does the same thing but goes backwards in the tree.

I set the keybinds as CTRL+SHIFT+N for next mistake and CTRL+SHIFT+P for previous mistake, but I'm open to discussing alternatives. I personally think CTRL+UP/DOWN arrows would be better, but the code that prevents scrolling makes it difficult to bind anything else to Up/Down arrows.

I also think having some kind of customization for the mistake threshold would be a good idea, I am just unsure of where that should live. For now it is hardcoded as a loss of 3 or more points.